### PR TITLE
deploy group2 after group1

### DIFF
--- a/consul-instances.tf
+++ b/consul-instances.tf
@@ -184,4 +184,6 @@ resource "aws_instance" "consul-server-group2" {
     Name = "consul-group2-server${count.index}"
     learn-consul-redundancy-zones = "join"
   }
+
+  depends_on = [ aws_instance.consul-server-group1 ]
 }


### PR DESCRIPTION
this change makes sure that the deployment of server group2 depends on group1, which means that group1 is deployed first, and consistently likely to acquire Consul server voting roles over group2